### PR TITLE
Fix useless definition guard

### DIFF
--- a/net.py
+++ b/net.py
@@ -76,7 +76,7 @@ class Net(object):
                     elif layerAct == 'maxout':
                         newLayers.append({
                             'type': 'maxout',
-                            'group_size': layer['group_size'] if group_size in layerKeys else 2
+                            'group_size': layer['group_size'] if 'group_size' in layerKeys else 2
                         })
                     else:
                         print 'Error: Unsupported activation'


### PR DESCRIPTION
Simply _stringified_ what was supposed to be a string: fixing if-statement.
